### PR TITLE
Switch to dockerhub mirror

### DIFF
--- a/vendor-diff/Dockerfile
+++ b/vendor-diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM docker.mirror.hashicorp.services/python:3-alpine
 
 LABEL "maintainer"="Kim Ngo <kngo@hashicorp.com>"
 LABEL "repository"="https://github.com/hashicorp/go-github-actions"


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. circleci/cimg images are excluded. 